### PR TITLE
fix: Prevent governance members from performing contract upgrades

### DIFF
--- a/contracts/GovImp.sol
+++ b/contracts/GovImp.sol
@@ -1341,4 +1341,12 @@ contract GovImp is
 
         return 0;
     }
+
+    function upgradeTo(address) external pure override {
+        revert("Invalid access");
+    }
+
+    function upgradeToAndCall(address, bytes memory) external payable override {
+        revert("Invalid access");
+    }
 }


### PR DESCRIPTION
### Feature
- Redifined the `upgradeTo` and `upgradeToAndCall` upgrade functions in the **GovImp** Contract